### PR TITLE
fix concurrent writes

### DIFF
--- a/component.json
+++ b/component.json
@@ -5,6 +5,7 @@
   "version": "0.0.1",
   "keywords": [],
   "dependencies": {
+    "visionmedia/debug": "*",
     "component/domify": "1.2.0"
   },
   "development": {

--- a/test/fixtures/a.js
+++ b/test/fixtures/a.js
@@ -1,0 +1,3 @@
+
+window.a = window.a || 0;
+window.a++;

--- a/test/fixtures/analytics-a.js
+++ b/test/fixtures/analytics-a.js
@@ -1,0 +1,2 @@
+
+document.write('<script src="fixtures/a.js"></script>');

--- a/test/fixtures/analytics-b.js
+++ b/test/fixtures/analytics-b.js
@@ -1,0 +1,4 @@
+
+setTimeout(function(){
+  document.write('<script src="fixtures/b.js"></script>');
+}, 100);

--- a/test/fixtures/b.js
+++ b/test/fixtures/b.js
@@ -1,0 +1,3 @@
+
+window.b = window.b || 0;
+window.b++;

--- a/test/index.js
+++ b/test/index.js
@@ -26,4 +26,18 @@ describe('document-write-replace', function(){
       done();
     })();
   })
+
+  it('should handle concurrent `replace(match, fn)`', function(done){
+    assert(write == document.write);
+    replace('a.js', end);
+    replace('b.js', end);
+    load('fixtures/analytics-a.js');
+    load('fixtures/analytics-b.js');
+
+    function end(){
+      end.times = end.times || 0;
+      if (2 == ++end.times) return done();
+      assert(write == document.write);
+    }
+  })
 });


### PR DESCRIPTION
this handles the case where

``` js
// a.js
write('<script src="analytics-a.js">');

// b.js
write('<script src="analytics-b.js">');

// mine.js
replace('analytics-a');
replace('analytics-b');
load('a.js');
load('b.js');
```

but there's still a problem, if `write()` isn't called in `a.js` or `b.js` (or both) `wait()` will keep waiting, so not sure, maybe we should have a timeout or something ?

cc @calvinfo maybe you have some ideas :D
